### PR TITLE
kdrive/BaosEnumerator: Fix wrong data length of manufacturer ID

### DIFF
--- a/kdrive/src/baos/BaosEnumerator.cpp
+++ b/kdrive/src/baos/BaosEnumerator.cpp
@@ -243,7 +243,7 @@ void BaosEnumerator::addDevice(const std::vector<unsigned char>& buffer, const I
 
 		if (static_cast<std::size_t>(manOffset + 7) < buffer.size())
 		{
-			const unsigned char mancode = buffer.at(manOffset + 2) << 8 | buffer.at(manOffset + 3);
+			const unsigned int mancode = buffer.at(manOffset + 2) << 8 | buffer.at(manOffset + 3);
 			const unsigned char protocol = buffer.at(manOffset + 6);
 			const unsigned char version = buffer.at(manOffset + 7);
 


### PR DESCRIPTION
Manufacturer ID in Search response reply is incorrectly parsed to one byte variable only.

See [Protocol description: KNX BAOS Binary](http://www.weinzierl.de/images/download/products/771/KNX_BAOS_Binary_Protocol_V2_0.pdf), page 54.

The upper byte was 'added' to the lower by mistake, so some other devices might by accepted as well (0x10B5, 0x05C0, ...).
